### PR TITLE
Use user-supplied or default-constructed string_type for invalid enumerators

### DIFF
--- a/wise_enum_detail.h
+++ b/wise_enum_detail.h
@@ -44,16 +44,6 @@ using string_type = WISE_ENUM_STRING_TYPE;
 }
 #endif
 
-#ifndef WISE_ENUM_INVALID_ENUMERATOR_STRING_VALUE
-namespace wise_enum {
-constexpr string_type invalid_enumerator_string_value{};
-}
-#else
-namespace wise_enum {
-constexpr string_type invalid_enumerator_string_value{WISE_ENUM_INVALID_ENUMERATOR_STRING_VALUE};
-}
-#endif
-
 #if __cplusplus == 201103
 #define WISE_ENUM_CONSTEXPR_14
 #else
@@ -206,5 +196,5 @@ WISE_ENUM_CONSTEXPR_14 bool compare(U u1, U u2) {
       loop(WISE_ENUM_IMPL_SWITCH_CASE, name, WISE_ENUM_IMPL_NOTHING,           \
            __VA_ARGS__)                                                        \
     }                                                                          \
-    return wise_enum::invalid_enumerator_string_value;                         \
+    return {};                                                                 \
   }

--- a/wise_enum_detail.h
+++ b/wise_enum_detail.h
@@ -44,6 +44,16 @@ using string_type = WISE_ENUM_STRING_TYPE;
 }
 #endif
 
+#ifndef WISE_ENUM_INVALID_ENUMERATOR_STRING_VALUE
+namespace wise_enum {
+constexpr string_type invalid_enumerator_string_value{};
+}
+#else
+namespace wise_enum {
+constexpr string_type invalid_enumerator_string_value{WISE_ENUM_INVALID_ENUMERATOR_STRING_VALUE};
+}
+#endif
+
 #if __cplusplus == 201103
 #define WISE_ENUM_CONSTEXPR_14
 #else
@@ -196,5 +206,5 @@ WISE_ENUM_CONSTEXPR_14 bool compare(U u1, U u2) {
       loop(WISE_ENUM_IMPL_SWITCH_CASE, name, WISE_ENUM_IMPL_NOTHING,           \
            __VA_ARGS__)                                                        \
     }                                                                          \
-    return nullptr;                                                            \
+    return wise_enum::invalid_enumerator_string_value;                         \
   }


### PR DESCRIPTION
- invalid enumerators now return wise_enum::invalid_enumerator_string_value (constexpr string_type)
- value can be supplied using WISE_ENUM_INVALID_ENUMERATOR_STRING_VALUE macro
- if the macro is not defined, string_type{} is used (which is non-breaking, as char const* default-constructs to nullptr and string_view also default-constructs as (nullptr, 0), which is the non-standard conforming behaviour observed on implementations where string_view{nullptr} works)