### PR TITLE
Remove throw via macro

### DIFF
--- a/compact_optional.h
+++ b/compact_optional.h
@@ -66,12 +66,18 @@ public:
     return m_storage != invalid;
   }
 
+#ifndef WISE_ENUM_NO_EXCEPTIONS
   constexpr T value() const {
     if (m_storage != invalid)
       return static_cast<T>(m_storage);
     else
       throw bad_optional_access{};
   }
+#else
+  constexpr T value() const {
+    return static_cast<T>(m_storage);
+  }
+#endif
 
   template <class U>
   constexpr T value_or(U &&u) {

--- a/compact_optional.h
+++ b/compact_optional.h
@@ -73,10 +73,6 @@ public:
     else
       throw bad_optional_access{};
   }
-#else
-  constexpr T value() const {
-    return static_cast<T>(m_storage);
-  }
 #endif
 
   template <class U>

--- a/optional.h
+++ b/optional.h
@@ -64,11 +64,6 @@ public:
     else
       throw bad_optional_access{};
   }
-#else
-  WISE_ENUM_CONSTEXPR_14 T &value() & { return m_t; }
-  constexpr const T &value() const & { return m_t; }
-  WISE_ENUM_CONSTEXPR_14 T &&value() && { return m_t; }
-  constexpr const T &&value() const && { return m_t; }
 #endif
 
   template <class U>

--- a/optional.h
+++ b/optional.h
@@ -37,7 +37,7 @@ public:
 
   constexpr explicit operator bool() const noexcept { return m_active; }
   constexpr bool has_value() const noexcept { return m_active; }
-  
+
 #ifndef WISE_ENUM_NO_EXCEPTIONS
   WISE_ENUM_CONSTEXPR_14 T &value() & {
     if (m_active)
@@ -51,7 +51,7 @@ public:
     else
       throw bad_optional_access{};
   }
-  
+
   WISE_ENUM_CONSTEXPR_14 T &&value() && {
     if (m_active)
       return m_t;

--- a/optional.h
+++ b/optional.h
@@ -37,7 +37,8 @@ public:
 
   constexpr explicit operator bool() const noexcept { return m_active; }
   constexpr bool has_value() const noexcept { return m_active; }
-
+  
+#ifndef WISE_ENUM_NO_EXCEPTIONS
   WISE_ENUM_CONSTEXPR_14 T &value() & {
     if (m_active)
       return m_t;
@@ -50,7 +51,7 @@ public:
     else
       throw bad_optional_access{};
   }
-
+  
   WISE_ENUM_CONSTEXPR_14 T &&value() && {
     if (m_active)
       return m_t;
@@ -63,6 +64,12 @@ public:
     else
       throw bad_optional_access{};
   }
+#else
+  WISE_ENUM_CONSTEXPR_14 T &value() & { return m_t; }
+  constexpr const T &value() const & { return m_t; }
+  WISE_ENUM_CONSTEXPR_14 T &&value() && { return m_t; }
+  constexpr const T &&value() const && { return m_t; }
+#endif
 
   template <class U>
   constexpr T value_or(U &&u) {


### PR DESCRIPTION
Pull request to solve #15 
If `WISE_ENUM_NO_EXCEPTIONS` macro is defined, `.value()` functions now blindly return the contained object, it is up to the user to make sure there is something to get.