### PR TITLE
Make compatible with sanitizers-cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)
 
-project(WiseEnum VERSION 3.0.0)
+project(WiseEnum VERSION 3.0.0 LANGUAGES CXX)
 
 option(BUILD_EXAMPLES "Build the examples" OFF)
 option(BUILD_TESTS "Build the tests" OFF)


### PR DESCRIPTION
This pull requests makes wise_enum compatible with [sanitizers-cmake](https://github.com/arsenm/sanitizers-cmake) by setting the language to C++ in the CMake project definition.

Without this wise_enum can't be used in projects that use sanitizers-cmake, because it needs to know the language of the project.