### PR TITLE
wise_enum_detail.h: add inline to strcmp compare

### DIFF
--- a/wise_enum_detail.h
+++ b/wise_enum_detail.h
@@ -70,7 +70,7 @@ struct is_wise_enum
           bool, !std::is_same<void, decltype(wise_enum_detail_array(
                                         Tag<T>{}))>::value> {};
 
-WISE_ENUM_CONSTEXPR_14 int strcmp(const char *s1, const char *s2) {
+WISE_ENUM_CONSTEXPR_14 inline int strcmp(const char *s1, const char *s2) {
   while (*s1 && (*s1 == *s2))
     s1++, s2++;
   if (*s1 < *s2) {
@@ -83,13 +83,13 @@ WISE_ENUM_CONSTEXPR_14 int strcmp(const char *s1, const char *s2) {
   }
 }
 
-WISE_ENUM_CONSTEXPR_14 bool compare(const char *s1, const char *s2) {
+WISE_ENUM_CONSTEXPR_14 inline bool compare(const char *s1, const char *s2) {
   return strcmp(s1, s2) == 0;
 }
 
 template <class U, class = typename std::enable_if<
                        !std::is_same<U, const char *>::value>::type>
-WISE_ENUM_CONSTEXPR_14 bool compare(U u1, U u2) {
+WISE_ENUM_CONSTEXPR_14 inline bool compare(U u1, U u2) {
   return u1 == u2;
 }
 } // namespace detail


### PR DESCRIPTION
missing inline for compare strcmp
it creates multiple defs symbols