### PR TITLE
Fix include directories in WiseEnumConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ configure_package_config_file(
 
 install(TARGETS wise_enum
         EXPORT "${targets_export_name}"
-        INCLUDES DESTINATION "${include_install_dir}"
+        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
         ARCHIVE DESTINATION "${lib_install_dir}")
 
 install(FILES ${interface_hdrs} DESTINATION "${include_install_dir}")


### PR DESCRIPTION
When the project is 'installed' via CMake, the headers are copied into
the directory: `${CMAKE_INSTALL_INCLUDE_DIR}/include/wise_enum`, so that
users get a 'stuttered' include path:
```
#include <wise_enum/wise_enum.h>
```

Currently (without the patch proposed here), the `WiseEnumTargets.cmake`
file generated by the `configure_package_config_file` command contains
the lines:
```
set_target_properties(WiseEnum::wise_enum PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;${_IMPORT_PREFIX}/include/wise_enum"
)
```

I believe the second of those paths is probably incorrect, as it allows
users to include wise_enum with either of:
```
// Correct. Allowed by ${_IMPORT_PREFIX}/include
#include <wise_enum/wise_enum.h> 

// Incorrect. Allowed by ${_IMPORT_PREFIX}/include/wise_enum
#include <wise_enum.h> 
```

This negates the benefits of the stuttering scheme, as `wise_enum.h` is
injected in to the global include path. The proposed patch removes the
`${_IMPORT_PREFIX}/include/wise_enum` path entry and ensures that
callers cannot use the `#include <wise_enum.h>` variant.